### PR TITLE
Fixed dead links to old repo/username

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,11 +93,11 @@ data to the expected formats (such as an integer), which will consume less
 space. This will allow the garbage collector to clean up the intermediary
 300MB data structure.</p>
 <h2><a name="Contributing-and-copyright" class="anchor" href="#Contributing-and-copyright">Contributing and copyright</a></h2>
-<p>The project is hosted on <a href="https://github.com/fsprojects/Pfarah">GitHub</a> where you can <a href="https://github.com/fsprojects/Pfarah/issues">report issues</a>,
+<p>The project is hosted on <a href="https://github.com/nickbabcock/Pfarah">GitHub</a> where you can <a href="https://github.com/nickbabcock/Pfarah/issues">report issues</a>,
 fork  the project and submit pull requests. You might also want to read the
-<a href="https://github.com/fsprojects/Pfarah/blob/master/README.md">library design notes</a> to understand how it works.</p>
+<a href="https://github.com/nickbabcock/Pfarah/blob/master/README.md">library design notes</a> to understand how it works.</p>
 <p>The library is available under the MIT license. For more information see the
-<a href="https://github.com/fsprojects/Pfarah/blob/master/LICENSE.txt">License file</a> in the GitHub repository.</p>
+<a href="https://github.com/nickbabcock/Pfarah/blob/master/LICENSE.txt">License file</a> in the GitHub repository.</p>
 
 <div class="tip" id="fs1">namespace Pfarah</div>
 <div class="tip" id="fs2">module Operators<br /><br />from Pfarah</div>


### PR DESCRIPTION
I don't know whether you changed your GitHub username or if this is a clone, but the old URLs were referencing a repo that didn't exist. Fixed that for you.